### PR TITLE
ci: use npm install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ node_js:
 
 script: echo "Running tests against $(node -v)..."
 
+install: npm install
+
 jobs:
   include:
     - stage: Produce Coverage


### PR DESCRIPTION
We should use `npm install` to get the same results that the consumers of this library get as lockfiles are not used by npmjs.

**Checks**

- [x] I've checked there are no linting errors.
- [x] I've checked the code is still at 100% test coverage.


**Added Actions (if relevant)**

- _List added actions here..._


**Are you happy to be listed as a contributor in the actions list [here](https://github.com/joshfarrant/shortcuts-js/issues/6)?**

_Yes_


**Any other information / comments**

_If this is your first time contributing, I'd love to hear what you thought about the process. Was it easy/hard to find the information you were looking for? Did the Contributing Guide make sense? What were your stumbling blocks? Basically, any and all feedback is encouraged!_
