### PR TITLE
Fixed scientific operations in calculate action

### DIFF
--- a/__tests__/actions/calculate.spec.ts
+++ b/__tests__/actions/calculate.spec.ts
@@ -64,7 +64,6 @@ describe('calculate function', () => {
   });
 
   it('builds a calculate action when a scientific operation is passed', () => {
-    const operation = '...';
     const scientificOperation = 'log(x)';
     const expected = {
       WFWorkflowActionIdentifier: 'is.workflow.actions.math',
@@ -73,14 +72,13 @@ describe('calculate function', () => {
         WFScientificMathOperation: scientificOperation,
       },
     };
-    const actual = calculate({ operation, scientificOperation });
+    const actual = calculate({ scientificOperation });
 
     expect(actual).toEqual(expected);
   });
 
   it('builds a calculate action when an operand and a scientific operation are passed', () => {
     const operand = 12;
-    const operation = '...';
     const scientificOperation = 'x^y';
     const expected = {
       WFWorkflowActionIdentifier: 'is.workflow.actions.math',
@@ -90,7 +88,7 @@ describe('calculate function', () => {
         WFScientificMathOperation: scientificOperation,
       },
     };
-    const actual = calculate({ operand, operation, scientificOperation });
+    const actual = calculate({ operand, scientificOperation });
 
     expect(actual).toEqual(expected);
   });

--- a/__tests__/actions/calculate.spec.ts
+++ b/__tests__/actions/calculate.spec.ts
@@ -6,6 +6,19 @@ describe('calculate function', () => {
     expect(typeof calculate).toBe('function');
   });
 
+  it('builds a calculate action when nothing is passed', () => {
+    const expected = {
+      WFWorkflowActionIdentifier: 'is.workflow.actions.math',
+      WFWorkflowActionParameters: {
+        WFMathOperand: 42,
+        WFMathOperation: '+',
+      },
+    };
+    const actual = calculate({});
+
+    expect(actual).toEqual(expected);
+  });
+
   it('builds a calculate action when an operand is passed', () => {
     const operand = 7;
     const expected = {
@@ -46,6 +59,38 @@ describe('calculate function', () => {
       },
     };
     const actual = calculate({ operand, operation });
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('builds a calculate action when a scientific operation is passed', () => {
+    const operation = '...';
+    const scientificOperation = 'log(x)';
+    const expected = {
+      WFWorkflowActionIdentifier: 'is.workflow.actions.math',
+      WFWorkflowActionParameters: {
+        WFMathOperation: '...',
+        WFScientificMathOperation: scientificOperation,
+      },
+    };
+    const actual = calculate({ operation, scientificOperation });
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('builds a calculate action when an operand and a scientific operation are passed', () => {
+    const operand = 12;
+    const operation = '...';
+    const scientificOperation = 'x^y';
+    const expected = {
+      WFWorkflowActionIdentifier: 'is.workflow.actions.math',
+      WFWorkflowActionParameters: {
+        WFMathOperation: '...',
+        WFScientificMathOperand: 12,
+        WFScientificMathOperation: scientificOperation,
+      },
+    };
+    const actual = calculate({ operand, operation, scientificOperation });
 
     expect(actual).toEqual(expected);
   });

--- a/src/actions/calculate.ts
+++ b/src/actions/calculate.ts
@@ -51,7 +51,7 @@ const calculate = (
   } = options;
 
   let parameters;
-  if (operation === '...' && scientificOperation) {
+  if (scientificOperation) {
     parameters = {
       WFMathOperation: '...',
       ...(operand !== undefined && { WFScientificMathOperand: operand }),

--- a/src/actions/calculate.ts
+++ b/src/actions/calculate.ts
@@ -1,7 +1,9 @@
 import { withActionOutput } from '../utils';
 
 import WFMathOperation from '../interfaces/WF/WFMathOperation';
+import WFScientificMathOperation from '../interfaces/WF/WFScientificMathOperation';
 import WFWorkflowAction from '../interfaces/WF/WFWorkflowAction';
+import WFWorkflowActionParameters from '../interfaces/WF/WFWorkflowActionParameters';
 
 /** @ignore */
 const operationsMap = new Map([
@@ -26,7 +28,7 @@ const operationsMap = new Map([
 const calculate = (
   options: {
     /** A second number to perform the operation on */
-    operand: number;
+    operand?: number;
     /** The operation to apply to the number. Defaults to '+' */
     operation?: (
       WFMathOperation
@@ -34,19 +36,37 @@ const calculate = (
       | 'x'
       | '/'
     );
+    /** The scientific operation to apply to the number */
+    scientificOperation?: (
+      WFScientificMathOperation
+      | 'sqrt'
+      | 'cbrt'
+    );
   },
 ): WFWorkflowAction => {
   const {
     operand,
     operation = '+',
+    scientificOperation,
   } = options;
+
+  let parameters;
+  if (operation === '...' && scientificOperation) {
+    parameters = {
+      WFMathOperation: '...',
+      ...(operand !== undefined && { WFScientificMathOperand: operand }),
+      WFScientificMathOperation: (operationsMap.get(scientificOperation) || scientificOperation),
+    };
+  } else {
+    parameters = {
+      WFMathOperand: operand || 42,
+      WFMathOperation: (operationsMap.get(operation) || operation),
+    };
+  }
 
   return {
     WFWorkflowActionIdentifier: 'is.workflow.actions.math',
-    WFWorkflowActionParameters: {
-      WFMathOperand: operand,
-      WFMathOperation: (operationsMap.get(operation) || operation) as WFMathOperation,
-    },
+    WFWorkflowActionParameters: parameters as WFWorkflowActionParameters,
   };
 };
 

--- a/src/interfaces/WF/WFMathOperation.ts
+++ b/src/interfaces/WF/WFMathOperation.ts
@@ -3,21 +3,7 @@ type WFMathOperation = (
   | '-'
   | '×'
   | '÷'
-  | 'Modulus'
-  | 'x^2'
-  | 'x^3'
-  | 'x^y'
-  | 'e^x'
-  | '10^x'
-  | 'ln(x)'
-  | 'log(x)'
-  | '√x'
-  | '∛x'
-  | 'x!'
-  | 'sin(x)'
-  | 'cos(x)'
-  | 'tan(x)'
-  | 'abs(x)'
+  | '...'
 );
 
 export default WFMathOperation;

--- a/src/interfaces/WF/WFScientificMathOperation.ts
+++ b/src/interfaces/WF/WFScientificMathOperation.ts
@@ -1,0 +1,19 @@
+type WFScientificMathOperation = (
+  'Modulus'
+  | 'x^2'
+  | 'x^3'
+  | 'x^y'
+  | 'e^x'
+  | '10^x'
+  | 'ln(x)'
+  | 'log(x)'
+  | '√x'
+  | '∛x'
+  | 'x!'
+  | 'sin(x)'
+  | 'cos(x)'
+  | 'tan(x)'
+  | 'abs(x)'
+);
+
+export default WFScientificMathOperation;

--- a/src/interfaces/WF/WFWorkflowActionParameters.ts
+++ b/src/interfaces/WF/WFWorkflowActionParameters.ts
@@ -15,6 +15,7 @@ import WFIPAddressSourceOption from './WFIPAddressSourceOption';
 import WFIPAddressTypeOption from './WFIPAddressTypeOption';
 import WFMathOperation from './WFMathOperation';
 import WFNetworkDetailsNetwork from './WFNetworkDetailsNetwork';
+import WFScientificMathOperation from './WFScientificMathOperation';
 import WFSerialization from './WFSerialization';
 import WFStatisticsOperation from './WFStatisticsOperation';
 
@@ -66,13 +67,15 @@ interface WFWorkflowActionParameters {
   WFMenuPrompt?: string;
   WFName?: string;
   WFNetworkDetailsNetwork?: WFNetworkDetailsNetwork;
-  WFNotificationActionTitle?: string;
   WFNotificationActionBody?: string;
   WFNotificationActionSound?: boolean;
+  WFNotificationActionTitle?: string;
   WFNumberActionNumber?: number;
   WFNumberValue?: number;
-  WFRandomNumberMinimum?: WFSerialization | number;
   WFRandomNumberMaximum?: WFSerialization | number;
+  WFRandomNumberMinimum?: WFSerialization | number;
+  WFScientificMathOperand?: number;
+  WFScientificMathOperation?: WFScientificMathOperation;
   WFShowWorkflow?: boolean;
   WFSSHHost?: WFSerialization | string;
   WFSSHPassword?: WFSerialization | string;


### PR DESCRIPTION
**Checks**

- [x] I've checked there are no linting errors.
- [x] I've checked the code is still at 100% test coverage.


**Added Actions (if relevant)**

- None


**Are you happy to be listed as a contributor on [Shortcuts.fun](https://shortcuts.fun)?**

Yes


**Any other information / comments**

- Fixes issue #41

Note: like in the Shortcuts app, here we have to use `'...'` when specifying a scientific operation:
```js
calculate({
  operand: 4,
  operation: '...',
  scientificOperation: 'x^y',
});
```