### PR TITLE
Add option to show/hide shortcut in widget

### DIFF
--- a/__tests__/_fixtures/actions.ts
+++ b/__tests__/_fixtures/actions.ts
@@ -30,8 +30,8 @@ export const testShortcutNoActions: WFWorkflow = {
   },
   WFWorkflowImportQuestions: [],
   WFWorkflowTypes: [
-    'NCWidget',
     'WatchKit',
+    'NCWidget',
   ],
   WFWorkflowInputContentItemClasses: [
     'WFAppStoreAppContentItem',
@@ -97,8 +97,8 @@ export const testShortcutWithActions: WFWorkflow = {
   },
   WFWorkflowImportQuestions: [],
   WFWorkflowTypes: [
-    'NCWidget',
     'WatchKit',
+    'NCWidget',
   ],
   WFWorkflowInputContentItemClasses: [
     'WFAppStoreAppContentItem',
@@ -131,8 +131,8 @@ export const testShortcutWithModifiedOptions: WFWorkflow = {
   },
   WFWorkflowImportQuestions: [],
   WFWorkflowTypes: [
-    'NCWidget',
     'WatchKit',
+    'NCWidget',
   ],
   WFWorkflowInputContentItemClasses: [
     'WFAppStoreAppContentItem',

--- a/__tests__/_fixtures/actions.ts
+++ b/__tests__/_fixtures/actions.ts
@@ -55,6 +55,39 @@ export const testShortcutNoActions: WFWorkflow = {
   WFWorkflowActions: [],
 };
 
+export const testShortcutNoActionsNoWidget: WFWorkflow = {
+  WFWorkflowClientVersion: '724',
+  WFWorkflowClientRelease: '2.1',
+  WFWorkflowIcon: {
+    WFWorkflowIconStartColor: 4274264319,
+    WFWorkflowIconGlyphNumber: 59446,
+  },
+  WFWorkflowImportQuestions: [],
+  WFWorkflowTypes: [
+    'WatchKit',
+  ],
+  WFWorkflowInputContentItemClasses: [
+    'WFAppStoreAppContentItem',
+    'WFArticleContentItem',
+    'WFContactContentItem',
+    'WFDateContentItem',
+    'WFEmailAddressContentItem',
+    'WFGenericFileContentItem',
+    'WFImageContentItem',
+    'WFiTunesProductContentItem',
+    'WFLocationContentItem',
+    'WFDCMapsLinkContentItem',
+    'WFAVAssetContentItem',
+    'WFPDFContentItem',
+    'WFPhoneNumberContentItem',
+    'WFRichTextContentItem',
+    'WFSafariWebPageContentItem',
+    'WFStringContentItem',
+    'WFURLContentItem',
+  ],
+  WFWorkflowActions: [],
+};
+
 export const testShortcutWithActions: WFWorkflow = {
   WFWorkflowClientVersion: '724',
   WFWorkflowClientRelease: '2.1',

--- a/__tests__/utils/buildShortcut.spec.ts
+++ b/__tests__/utils/buildShortcut.spec.ts
@@ -20,6 +20,7 @@ describe('buildShortcut function', () => {
         color: 4274264319,
         glyph: 59446,
       },
+      showInWidget: true,
     });
     const expected = encodeShortcut(template);
 
@@ -33,6 +34,7 @@ describe('buildShortcut function', () => {
         color: 4274264319,
         glyph: 59446,
       },
+      showInWidget: true,
     });
     const expected = encodeShortcut(template);
 
@@ -46,6 +48,7 @@ describe('buildShortcut function', () => {
         color: 1440408063,
         glyph: 59784,
       },
+      showInWidget: true,
     };
     const template = buildShortcutTemplate(testActions, options);
     const expected = encodeShortcut(template);
@@ -60,6 +63,7 @@ describe('buildShortcut function', () => {
         color: 1440408063,
         glyph: 59446,
       },
+      showInWidget: true,
     });
     const expected = encodeShortcut(template);
 
@@ -68,6 +72,20 @@ describe('buildShortcut function', () => {
         color: 1440408063,
       },
     });
+    expect(actual).toEqual(expected);
+  });
+
+  it('builds an encoded shortcut object that is not shown in shortcuts widget', () => {
+    const template = buildShortcutTemplate([], {
+      icon: {
+        color: 4274264319,
+        glyph: 59446,
+      },
+      showInWidget: false,
+    });
+    const expected = encodeShortcut(template);
+
+    const actual = buildShortcut([], { showInWidget: false });
     expect(actual).toEqual(expected);
   });
 

--- a/__tests__/utils/buildShortcutTemplate.spec.ts
+++ b/__tests__/utils/buildShortcutTemplate.spec.ts
@@ -1,17 +1,29 @@
 import { buildShortcutTemplate } from '../../src/utils';
 
+import BuildShortcutOptions from '../../src/interfaces/BuildShortcutOptions';
+
 import {
   testActions,
   testShortcutNoActions,
+  testShortcutNoActionsNoWidget,
   testShortcutWithActions,
   testShortcutWithModifiedOptions,
 } from '../_fixtures/actions';
 
-const defaultOptions = {
+const defaultOptions: BuildShortcutOptions = {
   icon: {
     color: 4274264319,
     glyph: 59446,
   },
+  showInWidget: true,
+};
+
+const noWidgetOptions: BuildShortcutOptions = {
+  icon: {
+    color: 4274264319,
+    glyph: 59446,
+  },
+  showInWidget: false,
 };
 
 describe('buildShortcutTemplate function', () => {
@@ -42,7 +54,15 @@ describe('buildShortcutTemplate function', () => {
         color: 3980825855,
         glyph: 59769,
       },
+      showInWidget: true,
     });
+    expect(actual).toMatchObject(expected);
+  });
+
+  it('builds a shortcut object that is not shown in shortcuts widget', () => {
+    const expected = testShortcutNoActionsNoWidget;
+
+    const actual = buildShortcutTemplate(undefined, noWidgetOptions);
     expect(actual).toMatchObject(expected);
   });
 

--- a/src/interfaces/BuildShortcutOptions.ts
+++ b/src/interfaces/BuildShortcutOptions.ts
@@ -3,6 +3,7 @@ interface BuildShortcutOptions {
     color: number;
     glyph: number;
   };
+  showInWidget: boolean;
 }
 
 export default BuildShortcutOptions;

--- a/src/utils/buildShortcut.ts
+++ b/src/utils/buildShortcut.ts
@@ -27,15 +27,18 @@ export const buildShortcut = (
     showInWidget: true,
   };
 
-  if (options && options.icon) {
-    completeOptions.icon = {
-      ...completeOptions.icon,
-      ...options.icon,
-    };
-  }
+  // Map to internal build options
+  if (options) {
+    if (options.icon) {
+      completeOptions.icon = {
+        ...completeOptions.icon,
+        ...options.icon,
+      };
+    }
 
-  if (options && options.showInWidget === false) {
-    completeOptions.showInWidget = false;
+    if (options.showInWidget === false) {
+      completeOptions.showInWidget = false;
+    }
   }
 
   const template = buildShortcutTemplate(actions, completeOptions);

--- a/src/utils/buildShortcut.ts
+++ b/src/utils/buildShortcut.ts
@@ -16,6 +16,7 @@ export const buildShortcut = (
       color?: number,
       glyph?: number,
     },
+    showInWidget?: boolean,
   },
 ): string => {
   const completeOptions = {
@@ -23,6 +24,7 @@ export const buildShortcut = (
       color: 4274264319, // Yellow
       glyph: 59446, // Keyboard
     },
+    showInWidget: true,
   };
 
   if (options && options.icon) {
@@ -30,6 +32,10 @@ export const buildShortcut = (
       ...completeOptions.icon,
       ...options.icon,
     };
+  }
+
+  if (options && options.showInWidget === false) {
+    completeOptions.showInWidget = false;
   }
 
   const template = buildShortcutTemplate(actions, completeOptions);

--- a/src/utils/buildShortcutTemplate.ts
+++ b/src/utils/buildShortcutTemplate.ts
@@ -18,8 +18,8 @@ export const buildShortcutTemplate = (
   },
   WFWorkflowImportQuestions: [],
   WFWorkflowTypes: [
-    ...(options.showInWidget ? ['NCWidget' as WFWorkflowType] : []),
     'WatchKit',
+    ...(options.showInWidget ? ['NCWidget' as WFWorkflowType] : []),
   ],
   WFWorkflowInputContentItemClasses: [
     'WFAppStoreAppContentItem',

--- a/src/utils/buildShortcutTemplate.ts
+++ b/src/utils/buildShortcutTemplate.ts
@@ -3,6 +3,7 @@ import { flatten } from './flatten';
 import BuildShortcutOptions from '../interfaces/BuildShortcutOptions';
 import WFWorkflow from '../interfaces/WF/WFWorkflow';
 import WFWorkflowActionsInterface from '../interfaces/WF/WFWorkflowAction';
+import WFWorkflowType from '../interfaces/WF/WFWorkflowType';
 
 /** @ignore */
 export const buildShortcutTemplate = (
@@ -17,7 +18,7 @@ export const buildShortcutTemplate = (
   },
   WFWorkflowImportQuestions: [],
   WFWorkflowTypes: [
-    'NCWidget',
+    ...(options.showInWidget ? ['NCWidget' as WFWorkflowType] : []),
     'WatchKit',
   ],
   WFWorkflowInputContentItemClasses: [


### PR DESCRIPTION
**Checks**

- [x] I've checked there are no linting errors.
- [x] I've checked the code is still at 100% test coverage.


**Are you happy to be listed as a contributor on [Shortcuts.fun](https://shortcuts.fun)?**

Yes!

**Any other information / comments**

This adds the ability to show/hide the shortcut in the widget.  While making this, I noticed a bug with the Shortcuts client: this option does not get imported correctly.  I am creating the correct structure, but when its imported, the option does not persist.

Ideally, we want 
```json
"WFWorkflowTypes": [
  "WatchKit",
],
```
with the removal of `NCWidget`.

The build creates this, but the option is not imported on the iPhone in the Shortcuts app.

Now for how I know it's a bug... When I added the `ActionExtension` option to the Workflow Types array, the lack of `NCWidget` imported successfully.

I generated this:
```json
"WFWorkflowTypes": [
  "WatchKit",
  "ActionExtension",
]
```
and the `Show in Widget` option was successfully imported as false, and `Show in Share Sheet` was successfully imported as true (I'm working share sheet next).

This PR adds the ability to toggle this option, and I'll look into reporting this client bug to Apple.