### PR TITLE
Docs: better handling of the NotFound page

### DIFF
--- a/docs/src/components/Docs/NotFound/content.md
+++ b/docs/src/components/Docs/NotFound/content.md
@@ -1,1 +1,5 @@
+## 404 Page Not Found
+
+This page is missing.
+
 [WIP]

--- a/docs/src/components/Docs/component.jsx
+++ b/docs/src/components/Docs/component.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route } from 'react-router';
+import { Route, Switch } from 'react-router';
 import { Link, NavLink } from 'react-router-dom';
 
 import Actions from './Actions';
@@ -158,13 +158,15 @@ export default class Component extends React.Component {
         </div>
 
         <div className={styles.content}>
-          <Route path="/" exact component={GettingStarted} />
-          <Route path="/variables" component={Variables} />
-          <Route path="/actions/:name?" component={Actions} />
-          <Route path="/metadata" exact component={Metadata} />
-          <Route path="/metadata/icon" component={Metadata_ShortcutIcon} />
-          <Route path="/contributing/action-icons" component={Contributing_ActionIcons} />
-          <Route component={NotFound} />
+          <Switch>
+            <Route path="/" exact component={GettingStarted} />
+            <Route path="/variables" component={Variables} />
+            <Route path="/actions/:name?" component={Actions} />
+            <Route path="/metadata" exact component={Metadata} />
+            <Route path="/metadata/icon" component={Metadata_ShortcutIcon} />
+            <Route path="/contributing/action-icons" component={Contributing_ActionIcons} />
+            <Route component={NotFound} />
+          </Switch>
         </div>
       </div>
     );


### PR DESCRIPTION
**Checks**

- [x] I've checked there are no linting errors.
- [x] I've checked the code is still at 100% test coverage.

**Added Actions (if relevant)**

- None


**Are you happy to be listed as a contributor on [Shortcuts.fun](https://shortcuts.fun)?**

Yes


**Any other information / comments**

This pull request adds a `react-router` `<Switch>` and shows the NotFound page only if no routes are matching.