### PR TITLE
Add speakText

### DIFF
--- a/__tests__/actions/speakText.spec.ts
+++ b/__tests__/actions/speakText.spec.ts
@@ -11,8 +11,7 @@ describe('speakText function', () => {
       WFWorkflowActionParameters: {
         WFSpeakTextLanguage: 'Default',
         WFSpeakTextPitch: 1.0,
-        WFSpeakTextRate: 1.0,
-        WFText: '',
+        WFSpeakTextRate: 0.5,
         WFSpeakTextVoice: 'Default',
         WFSpeakTextWait: true,
       },
@@ -26,7 +25,6 @@ describe('speakText function', () => {
     const testLanguage = 'English';
     const testPitch = 0.75;
     const testRate = 0.5;
-    const testText = 'Hello World';
     const testVoice = 'Irish';
     const testWaitUntilFinished = false;
 
@@ -36,7 +34,6 @@ describe('speakText function', () => {
         WFSpeakTextLanguage: testLanguage,
         WFSpeakTextPitch: testPitch,
         WFSpeakTextRate: testRate,
-        WFText: testText,
         WFSpeakTextVoice: testVoice,
         WFSpeakTextWait: testWaitUntilFinished,
       },
@@ -45,7 +42,6 @@ describe('speakText function', () => {
       language: 'English',
       pitch: 0.75,
       rate: 0.5,
-      text: 'Hello World',
       voice: 'Irish',
       waitUntilFinished: false,
     });

--- a/__tests__/actions/speakText.spec.ts
+++ b/__tests__/actions/speakText.spec.ts
@@ -1,0 +1,55 @@
+import { speakText } from '../../src/actions';
+
+describe('speakText function', () => {
+  it('is a function', () => {
+    expect(typeof speakText).toBe('function');
+  });
+
+  it('builds a speakText action when no parameters are passed', () => {
+    const expected = {
+      WFWorkflowActionIdentifier: 'is.workflow.actions.speaktext',
+      WFWorkflowActionParameters: {
+        WFSpeakTextLanguage: 'Default',
+        WFSpeakTextPitch: 1.0,
+        WFSpeakTextRate: 1.0,
+        WFText: '',
+        WFSpeakTextVoice: 'Default',
+        WFSpeakTextWait: true,
+      },
+    };
+    const actual = speakText({});
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('builds a text action when parameters are passed', () => {
+    const testLanguage = 'English';
+    const testPitch = 0.75;
+    const testRate = 0.5;
+    const testText = 'Hello World';
+    const testVoice = 'Irish';
+    const testWaitUntilFinished = false;
+
+    const expected = {
+      WFWorkflowActionIdentifier: 'is.workflow.actions.speaktext',
+      WFWorkflowActionParameters: {
+        WFSpeakTextLanguage: testLanguage,
+        WFSpeakTextPitch: testPitch,
+        WFSpeakTextRate: testRate,
+        WFText: testText,
+        WFSpeakTextVoice: testVoice,
+        WFSpeakTextWait: testWaitUntilFinished,
+      },
+    };
+    const actual = speakText({
+      language: 'English',
+      pitch: 0.75,
+      rate: 0.5,
+      text: 'Hello World',
+      voice: 'Irish',
+      waitUntilFinished: false,
+    });
+
+    expect(actual).toEqual(expected);
+  });
+});

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -114,6 +114,7 @@ import showNotification from './showNotification';
 import showResult from './showResult';
 import skipBack from './skipBack';
 import skipForward from './skipForward';
+import speakText from './speakText';
 import text from './text';
 import trimMedia from './trimMedia';
 import tweet from './tweet';
@@ -244,6 +245,7 @@ export {
   showResult,
   skipBack,
   skipForward,
+  speakText,
   text,
   tweet,
   trimMedia,

--- a/src/actions/speakText.ts
+++ b/src/actions/speakText.ts
@@ -9,7 +9,6 @@ import WFWorkflowAction from '../interfaces/WF/WFWorkflowAction';
  *
  * ```js
  * speakText({
- *   text: 'Well hello there!',
  *   language: 'Default',
  *   pitch: 1.0,
  *   rate: 0,

--- a/src/actions/speakText.ts
+++ b/src/actions/speakText.ts
@@ -1,4 +1,3 @@
-import WFSerialization from '../interfaces/WF/WFSerialization';
 import WFWorkflowAction from '../interfaces/WF/WFWorkflowAction';
 
 /**
@@ -10,7 +9,12 @@ import WFWorkflowAction from '../interfaces/WF/WFWorkflowAction';
  *
  * ```js
  * speakText({
- *   text: 'Some lovely text!',
+ *   text: 'Well hello there!',
+ *   language: 'Default',
+ *   pitch: 1.0,
+ *   rate: 0,
+ *   voice: 'Default',
+ *   waitUntilFinished: true,
  * });
  * ```
  */
@@ -19,21 +23,18 @@ const speakText = (
   {
     language = 'Default',
     pitch = 1.0,
-    rate = 1.0,
-    text = '',
+    rate = 0.5,
     voice = 'Default',
     waitUntilFinished = true,
   }: {
     /** The language to use when speaking text */
-    language?: string, // TODO: --------verify type is correct.----------
+    language?: string,
     /** The pitch to use when speaking text */
     pitch?: number
     /** The rate to use when speaking text */
     rate?: number
-    /** The text to speak */
-    text?: WFSerialization | string,
     /** The voice to use when speaking text */
-    voice?: string, // TODO: --------verify type is correct.----------
+    voice?: string,
     /** Should we wait until the speaking is finished to run the next action */
     waitUntilFinished?: boolean,
   },
@@ -43,7 +44,6 @@ const speakText = (
     WFSpeakTextLanguage: language,
     WFSpeakTextPitch: pitch,
     WFSpeakTextRate: rate,
-    WFText: text,
     WFSpeakTextVoice: voice,
     WFSpeakTextWait: waitUntilFinished,
   },

--- a/src/actions/speakText.ts
+++ b/src/actions/speakText.ts
@@ -1,0 +1,52 @@
+import WFSerialization from '../interfaces/WF/WFSerialization';
+import WFWorkflowAction from '../interfaces/WF/WFWorkflowAction';
+
+/**
+ * @action Speak Text
+ * @section Content Types > Documents > Speak Text
+ * @icon Documents
+ *
+ * Speaks the inputted text aloud.
+ *
+ * ```js
+ * speakText({
+ *   text: 'Some lovely text!',
+ * });
+ * ```
+ */
+
+const speakText = (
+  {
+    language = 'Default',
+    pitch = 1.0,
+    rate = 1.0,
+    text = '',
+    voice = 'Default',
+    waitUntilFinished = true,
+  }: {
+    /** The language to use when speaking text */
+    language?: string, // TODO: --------verify type is correct.----------
+    /** The pitch to use when speaking text */
+    pitch?: number
+    /** The rate to use when speaking text */
+    rate?: number
+    /** The text to speak */
+    text?: WFSerialization | string,
+    /** The voice to use when speaking text */
+    voice?: string, // TODO: --------verify type is correct.----------
+    /** Should we wait until the speaking is finished to run the next action */
+    waitUntilFinished?: boolean,
+  },
+): WFWorkflowAction => ({
+  WFWorkflowActionIdentifier: 'is.workflow.actions.speaktext',
+  WFWorkflowActionParameters: {
+    WFSpeakTextLanguage: language,
+    WFSpeakTextPitch: pitch,
+    WFSpeakTextRate: rate,
+    WFText: text,
+    WFSpeakTextVoice: voice,
+    WFSpeakTextWait: waitUntilFinished,
+  },
+});
+
+export default speakText;

--- a/src/interfaces/WF/WFWorkflowActionIdentifier.ts
+++ b/src/interfaces/WF/WFWorkflowActionIdentifier.ts
@@ -111,6 +111,7 @@ type WFWorkflowActionIdentifier = (
   | 'is.workflow.actions.showresult'
   | 'is.workflow.actions.skipback'
   | 'is.workflow.actions.skipforward'
+  | 'is.workflow.actions.speaktext'
   | 'is.workflow.actions.statistics'
   | 'is.workflow.actions.text.changecase'
   | 'is.workflow.actions.text.match'

--- a/src/interfaces/WF/WFWorkflowActionParameters.ts
+++ b/src/interfaces/WF/WFWorkflowActionParameters.ts
@@ -116,10 +116,10 @@ interface WFWorkflowActionParameters {
   WFSSHScript?: WFSerialization | string;
   WFSSHUser?: WFSerialization | string;
   WFSkipBackBehavior?: WFSkipBackBehavior;
-  WFSpeakTextLanguage?: string; // TODO: Make a type?
+  WFSpeakTextLanguage?: string;
   WFSpeakTextPitch?: number;
   WFSpeakTextRate?: number;
-  WFSpeakTextVoice?: string; // TODO: Make a type?
+  WFSpeakTextVoice?: string;
   WFSpeakTextWait?: boolean;
   WFStatisticsOperation?: WFSerialization | WFStatisticsOperation;
   WFText?: WFSerialization | string;

--- a/src/interfaces/WF/WFWorkflowActionParameters.ts
+++ b/src/interfaces/WF/WFWorkflowActionParameters.ts
@@ -116,7 +116,13 @@ interface WFWorkflowActionParameters {
   WFSSHScript?: WFSerialization | string;
   WFSSHUser?: WFSerialization | string;
   WFSkipBackBehavior?: WFSkipBackBehavior;
+  WFSpeakTextLanguage?: string; // TODO: Make a type?
+  WFSpeakTextPitch?: number;
+  WFSpeakTextRate?: number;
+  WFSpeakTextVoice?: string; // TODO: Make a type?
+  WFSpeakTextWait?: boolean;
   WFStatisticsOperation?: WFSerialization | WFStatisticsOperation;
+  WFText?: WFSerialization | string;
   WFTextActionText?: WFSerialization | string;
   WFTime?: WFSerialization | string;
   WFTimeFormatStyle?: WFSerialization | WFTimeFormatStyle;


### PR DESCRIPTION
_Please delete all sections in italics before submitting this PR._

**Checks**

- [x] I've checked there are no linting errors.
- [x] I've checked the code is still at 100% test coverage.


**Added Actions**

- _speakText_


**Are you happy to be listed as a contributor on [Shortcuts.fun](https://shortcuts.fun)?**

_Yes_ 


**Any other information / comments**
- _For now I used a type of `string` for `WFSpeakTextLanguage` and `WFSpeakTextVoice` because I was unable to find any documentation on the original type options. I test generated a shortcut and it seems to have worked passing in `'default'`._
- _First time contributing, I had trouble running `parse.js` because I was unable to get the shortcut file copied over from iOS to my dev system. Airdropping only seemed to open the link in a browser and since its a shortcut file it just links back to the apple store._
